### PR TITLE
feat: Avoid unnecessary enqueueing of `style.css`

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ This file is primarily used to:
 - Register **custom templates**, **template parts**, and **patterns**.
 
 > [!IMPORTANT]
-> **It is **not** used for applying styles.**
+> **It's _not_ used for applying styles.**
 
 ### `style.css`
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ This file is primarily used to:
 WordPress requires this file solely for theme registration metadata, such as the theme's name, author and version.
 
 > [!IMPORTANT]
-> **It is **not** used for adding custom CSS.**
+> This file is for metadata only. **It's _not_ enqueued by the theme. Do _not_ use it for adding any CSS.**
 
 ### Theme's main styles
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  */
 
-// Remove default WordPress styles
+// Remove WordPress defaults
 require_once get_theme_file_path( 'inc/remove-wp-defaults.php' );
 
 // Custom Blocks

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -5,6 +5,7 @@
  * @link https://developer.wordpress.org/themes/core-concepts/including-assets/#including-css
  */
 
+
 /**
  * Enqueue stylesheets on the front end of the website.
  *
@@ -14,17 +15,8 @@
  * @return void
  */
 function themeslug_enqueue_styles() {
-	$theme_version = wp_get_theme()->get( 'Version' );
+	$theme_version = wp_get_theme()->get('Version');
 
-	// Active theme's style.css file
-	wp_enqueue_style(
-		'themeslug-theme-stylesheet',
-		get_stylesheet_uri(),
-		[],
-		$theme_version
-	);
-
-	// All the styles
 	wp_enqueue_style(
 		'themeslug-styles',
 		get_theme_file_uri('build-css/global.css'),
@@ -32,7 +24,8 @@ function themeslug_enqueue_styles() {
 		$theme_version
 	);
 }
-add_action( 'wp_enqueue_scripts', 'themeslug_enqueue_styles' );
+add_action('wp_enqueue_scripts', 'themeslug_enqueue_styles');
+
 
 /**
  * Enqueue stylesheets in the Editor.
@@ -43,14 +36,13 @@ add_action( 'wp_enqueue_scripts', 'themeslug_enqueue_styles' );
  * @return void
  */
 function themeslug_add_editor_styles() {
-	add_editor_style( array(
-		// Active theme's style.css file
-		get_stylesheet_uri(),
-		// All the styles
-		get_theme_file_uri('build-css/global.css'),
-	) );
+	add_editor_style(
+		[
+			get_theme_file_uri('build-css/global.css'),
+		]
+	);
 }
-add_action( 'after_setup_theme', 'themeslug_add_editor_styles' );
+add_action('after_setup_theme', 'themeslug_add_editor_styles');
 
 
 /**

--- a/style.css
+++ b/style.css
@@ -15,8 +15,7 @@ License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 */
 
 /*
-IMPORTANT:
-- This file is *not* used for adding any custom CSS.
-- Add styles in the src/styles/ directory.
-- See the README.md file for more info.
+IMPORTANT!
+This file is for theme metadata only. It's *not* enqueued by the theme. Do *not* use it for adding any CSS.
+See the README file for more info.
 */


### PR DESCRIPTION
In this theme, the `style.css` file is for theme metadata only. **It's *not* enqueued by the theme.**

See the README file for more info.