### PR TITLE
chore: Update minimum required PHP version to 7.2

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,7 +9,7 @@ Tags:
 Text Domain:       themeslug
 Tested up to:      6.8
 Requires at least: 6.8
-Requires PHP:      8.0
+Requires PHP:      7.2
 License:           GNU General Public License v2.0 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 */


### PR DESCRIPTION
As of today, 2025/08/07, the minimum supported PHP version in WordPress core is 7.2.

Reference:
https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/