### PR TITLE
ci(release): Add automated release and changelog workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          # Uses the default GitHub Actions token. If you need a PAT, ensure RELEASE_PLEASE_TOKEN is set in repository secrets.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          release-type: node


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to automate release management for the block theme. The workflow uses `googleapis/release-please-action` to automatically generate changelogs and create GitHub releases and tags based on semantic commit messages.