### PR TITLE
feat(styles): Implement CSS Cascade Layers system

### DIFF
--- a/inc/remove-wp-defaults.php
+++ b/inc/remove-wp-defaults.php
@@ -211,21 +211,13 @@ add_action('enqueue_block_editor_assets', 'themeslug_unregister_wp_block_style_v
  * @link https://fullsiteediting.com/lessons/how-to-remove-default-block-styles/
  */
 function themeslug_remove_global_styles() {
-	wp_dequeue_style('global-styles');
+	// wp_dequeue_style('global-styles');
 }
-add_action('wp_enqueue_scripts', 'themeslug_remove_global_styles', 100);
+// add_action('wp_enqueue_scripts', 'themeslug_remove_global_styles', 100);
 
 
 // TODO: Check.
 /**
  * Remove global styles on the front.
  */
-remove_action('wp_enqueue_scripts', 'wp_enqueue_global_styles');
-
-
-/**
- * Remove the block-library stylesheet itself from loading.
- */
-add_action( 'wp_enqueue_scripts', function() {
-	wp_deregister_style( 'wp-block-library' );
-}, 100 );
+// remove_action('wp_enqueue_scripts', 'wp_enqueue_global_styles');

--- a/inc/remove-wp-defaults.php
+++ b/inc/remove-wp-defaults.php
@@ -211,13 +211,21 @@ add_action('enqueue_block_editor_assets', 'themeslug_unregister_wp_block_style_v
  * @link https://fullsiteediting.com/lessons/how-to-remove-default-block-styles/
  */
 function themeslug_remove_global_styles() {
-	// wp_dequeue_style('global-styles');
+	wp_dequeue_style('global-styles');
 }
-// add_action('wp_enqueue_scripts', 'themeslug_remove_global_styles', 100);
+add_action('wp_enqueue_scripts', 'themeslug_remove_global_styles', 100);
 
 
 // TODO: Check.
 /**
  * Remove global styles on the front.
  */
-// remove_action('wp_enqueue_scripts', 'wp_enqueue_global_styles');
+remove_action('wp_enqueue_scripts', 'wp_enqueue_global_styles');
+
+
+/**
+ * Remove the block-library stylesheet itself from loading.
+ */
+add_action( 'wp_enqueue_scripts', function() {
+	wp_deregister_style( 'wp-block-library' );
+}, 100 );

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -55,11 +55,13 @@ function themeslug_get_layer_config() {
 		// Defines the final order of all top-level layers.
 		'order'   => [
 			'wordpress',
+			'plugins',
 			'theme',
 		],
 		// Maps specific stylesheet 'handles' to a layer.
 		'map'     => [
 			'themeslug-styles' => 'theme',
+			// e.g. 'plugin_handle' => 'plugins',
 		],
 		// The default layer for any handle not found in the map.
 		'default' => 'wordpress',

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -6,6 +6,11 @@
  */
 
 
+// Define layer names as a single source of truth.
+define( 'THEMESLUG_WP_LAYER', 'wordpress' );
+define( 'THEMESLUG_THEME_LAYER', 'theme' );
+
+
 /**
  * Enqueue stylesheets on the front end of the website.
  *
@@ -55,8 +60,11 @@ function themeslug_define_cascade_layers() {
 	wp_register_style( 'themeslug-layer-definition', false );
 	wp_enqueue_style( 'themeslug-layer-definition' );
 
+	// Use the constants to build the layer definition string.
+	$layer_css = sprintf( '@layer %s, %s;', THEMESLUG_WP_LAYER, THEMESLUG_THEME_LAYER );
+
 	// Add the layer definition as an inline style. This will be the first style block.
-	wp_add_inline_style( 'themeslug-layer-definition', '@layer wordpress, theme;' );
+	wp_add_inline_style( 'themeslug-layer-definition', $layer_css );
 }
 add_action( 'wp_enqueue_scripts', 'themeslug_define_cascade_layers', 5 );
 
@@ -95,17 +103,16 @@ function themeslug_enqueue_layered_scripts() {
 
 		if ( 'themeslug-styles' === $handle ) {
 			// This is our theme stylesheet.
-			if ( $src_exists ) {
-				$code .= '@import url("' . $style->src . '") layer(theme);';
-			}
-			$code .= '@layer theme {';
+			$layer_name = THEMESLUG_THEME_LAYER;
 		} else {
 			// This is a WordPress core or plugin stylesheet.
-			if ( $src_exists ) {
-				$code .= '@import url("' . $style->src . '") layer(wordpress);';
-			}
-			$code .= '@layer wordpress {';
+			$layer_name = THEMESLUG_WP_LAYER;
 		}
+
+		if ( $src_exists ) {
+			$code .= sprintf( '@import url("%s") layer(%s);', $style->src, $layer_name );
+		}
+		$code .= sprintf( '@layer %s {', $layer_name );
 
 		$after = $after_data ?: [];
 		array_unshift( $after, $code );

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -43,3 +43,54 @@ function themeslug_add_editor_styles() {
 	);
 }
 add_action('after_setup_theme', 'themeslug_add_editor_styles');
+
+
+// We use 'wp_enqueue_scripts' action with a very high priority so that it runs
+// last. This way we make sure that all plugins and the theme have enqueued
+// their styles and they are available in global $wp_styles object.
+// add_action( 'wp_enqueue_scripts', 'enqueue_layered_scripts', 9999999999 );
+
+function enqueue_layered_scripts() {
+	global $wp_styles;
+	// Get all styles that will be enqueued by WordPress
+	$styles = $wp_styles->registered;
+	// Define the layers and their order.
+	// We assign all styles loaded by WordPress to 'normal-styles' layer.
+	// We also define another layer, 'stronger-styles', which has a higher precendence.
+	// We can put any styles we want in there.
+	$layers = '@layer normal-styles, stronger-styles;';
+	// Iterate through the styles in order to change the way they are enqueued
+	foreach ( $styles as $key => $style ) {
+		// Check if the style loads a css file
+		$src_exists = is_string($styles[$key]->src);
+		// Prepare the CSS code that will be loaded in place of the <link> tag.
+		// First, we define the layers and their order. Unfortunately we cannot
+		// be sure which style in the list will be loaded first. So we need to
+		// put the definition of the layers in every CSS code.
+		$code = $layers.' ';
+		// Then we add an @import rule to load the CSS file, if exists. We set
+		// the layer of the imported file to be 'normal-styles'.
+		if ( $src_exists ) $code .= '@import url("'.$style->src.'") layer(normal-styles); ';
+		// The style may contain extra CSS code that has been added through
+		// add_inline_style() function. We also need to put this code inside
+		// 'normal-styles' layer. We do this by enclosing the code inside a
+		// @layer rule. We prepend '@layer normal-styles {' inside the extra CSS
+		// code.
+		// Notice that we do not close the opening @layer block. We do this on
+		// purpose because themes or plugins may add more CSS code after this
+		// function and we want to have that too inside the layer. It is ok that
+		// we do not close the @layer block, the browser will do it
+		// automatically.
+		$code .= '@layer normal-styles { ';
+		$after = $wp_styles->get_data( $style->handle, 'after' );
+		if ( ! $after ) $after = array();
+		// We prepend the prepared CSS code to the extra CSS code of the style.
+		array_unshift($after , $code);
+		$wp_styles->add_data( $style->handle, 'after', $after );
+		// We empty the styles 'src' property so that the style is not loaded
+		// with a <link> tag.
+		if ( $src_exists ) $styles[$key]->src = "";
+	}
+	// We can put more CSS code here that is loaded in 'stronger-styles' and has
+	// higher precendence over any other styles loaded above.
+}

--- a/inc/styles.php
+++ b/inc/styles.php
@@ -52,45 +52,55 @@ add_action('after_setup_theme', 'themeslug_add_editor_styles');
 
 function enqueue_layered_scripts() {
 	global $wp_styles;
+
 	// Get all styles that will be enqueued by WordPress
 	$styles = $wp_styles->registered;
+
 	// Define the layers and their order.
-	// We assign all styles loaded by WordPress to 'normal-styles' layer.
-	// We also define another layer, 'stronger-styles', which has a higher precendence.
+	// We assign all styles loaded by WordPress to 'wordpress' layer.
+	// We also define another layer, 'theme', which has a higher precendence.
 	// We can put any styles we want in there.
-	$layers = '@layer normal-styles, stronger-styles;';
+	$layers = '@layer wordpress, theme;';
+
 	// Iterate through the styles in order to change the way they are enqueued
 	foreach ( $styles as $key => $style ) {
 		// Check if the style loads a css file
 		$src_exists = is_string($styles[$key]->src);
+
 		// Prepare the CSS code that will be loaded in place of the <link> tag.
 		// First, we define the layers and their order. Unfortunately we cannot
 		// be sure which style in the list will be loaded first. So we need to
 		// put the definition of the layers in every CSS code.
 		$code = $layers.' ';
+
 		// Then we add an @import rule to load the CSS file, if exists. We set
-		// the layer of the imported file to be 'normal-styles'.
-		if ( $src_exists ) $code .= '@import url("'.$style->src.'") layer(normal-styles); ';
+		// the layer of the imported file to be 'wordpress'.
+		if ( $src_exists ) $code .= '@import url("'.$style->src.'") layer(wordpress); ';
+
 		// The style may contain extra CSS code that has been added through
 		// add_inline_style() function. We also need to put this code inside
-		// 'normal-styles' layer. We do this by enclosing the code inside a
-		// @layer rule. We prepend '@layer normal-styles {' inside the extra CSS
+		// 'wordpress' layer. We do this by enclosing the code inside a
+		// @layer rule. We prepend '@layer wordpress {' inside the extra CSS
 		// code.
 		// Notice that we do not close the opening @layer block. We do this on
 		// purpose because themes or plugins may add more CSS code after this
 		// function and we want to have that too inside the layer. It is ok that
 		// we do not close the @layer block, the browser will do it
 		// automatically.
-		$code .= '@layer normal-styles { ';
+		$code .= '@layer wordpress { ';
 		$after = $wp_styles->get_data( $style->handle, 'after' );
+
 		if ( ! $after ) $after = array();
+
 		// We prepend the prepared CSS code to the extra CSS code of the style.
 		array_unshift($after , $code);
 		$wp_styles->add_data( $style->handle, 'after', $after );
+
 		// We empty the styles 'src' property so that the style is not loaded
 		// with a <link> tag.
 		if ( $src_exists ) $styles[$key]->src = "";
 	}
-	// We can put more CSS code here that is loaded in 'stronger-styles' and has
+
+	// We can put more CSS code here that is loaded in 'theme' and has
 	// higher precendence over any other styles loaded above.
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "themeslug",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"private": true,
 	"description": "",
 	"keywords": [],

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,13 +4,14 @@ This specific import order is critical for correct CSS specificity.
 See the README file for more info.
 */
 
-@import "../../../../../wp-includes/css/dist/block-library/style.min.css" layer(wordpress);
-@import "global/reset.css";
-@import "global/custom-media-queries.css";
-@import "global/variables-system-tokens.css";
-@import "global/variables-component-tokens.css";
-@import "global/global-styles.css";
-@import-glob "compositions/*.css";
-@import-glob "regions/**/*.css";
-@import-glob "blocks/**/*.css";
-@import-glob "utilities/*.css";
+@layer reset, variables.custom-media-queries, variables.primitives, variables.semantic, global, layouts, blocks, regions, utilities;
+
+@import "global/reset.css" layer(reset);
+@import "global/custom-media-queries.css" layer(variables.custom-media-queries);
+@import "global/variables-system-tokens.css" layer(variables.primitives);
+@import "global/variables-component-tokens.css" layer(variables.semantic);
+@import "global/global-styles.css" layer(global);
+@import-glob "compositions/*.css" layer(layouts);
+@import-glob "blocks/**/*.css" layer(blocks);
+@import-glob "regions/**/*.css" layer(regions);
+@import-glob "utilities/*.css" layer(utilities);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,6 +4,7 @@ This specific import order is critical for correct CSS specificity.
 See the README file for more info.
 */
 
+@import "../../../../../wp-includes/css/dist/block-library/style.min.css" layer(wordpress);
 @import "global/reset.css";
 @import "global/custom-media-queries.css";
 @import "global/variables-system-tokens.css";

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,12 +4,12 @@ This specific import order is critical for correct CSS specificity.
 See the README file for more info.
 */
 
-@layer reset, variables.custom-media-queries, variables.primitives, variables.semantic, global, layouts, blocks, regions, utilities;
+@layer reset, variables, global, layouts, blocks, regions, utilities;
 
 @import "global/reset.css" layer(reset);
-@import "global/custom-media-queries.css" layer(variables.custom-media-queries);
-@import "global/variables-system-tokens.css" layer(variables.primitives);
-@import "global/variables-component-tokens.css" layer(variables.semantic);
+@import "global/custom-media-queries.css" layer(variables);
+@import "global/variables-system-tokens.css" layer(variables);
+@import "global/variables-component-tokens.css" layer(variables);
 @import "global/global-styles.css" layer(global);
 @import-glob "compositions/*.css" layer(layouts);
 @import-glob "blocks/**/*.css" layer(blocks);

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:        themename
 Theme URI:
 Description:
-Version:           0.1.0
+Version:           0.2.0
 Author:            themeauthor
 Author URI:
 Tags:


### PR DESCRIPTION
Introduces a comprehensive system for CSS Cascade Layers to provide
granular control over stylesheet precedence and create a predictable
styling architecture.

The PHP logic in `inc/styles.php` now intercepts all enqueued
stylesheets and re-formats them into a layered structure. This is
managed by a central configuration function that establishes the
following top-level layer order:
- `wordpress`
- `plugins`
- `theme`

The theme's internal stylesheet (`src/styles/global.css`) is also
refactored to use its own set of nested layers, ensuring a consistent
and organized cascade from reset styles to utilities.

Version is bumped to 0.2.0 to reflect this new feature.