### PR TITLE
feat: Add Gravity Forms integration

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -25,3 +25,6 @@ require_once get_theme_file_path( 'includes/styles.php' );
 
 // Front-end JavaScript
 require_once get_theme_file_path( 'includes/scripts.php' );
+
+// Plugin: Gravity Forms
+require_once get_theme_file_path( 'includes/plugin-gravityforms.php' );

--- a/includes/plugin-gravityforms.php
+++ b/includes/plugin-gravityforms.php
@@ -3,6 +3,8 @@
  * Gravity Forms customizations.
  *
  * All actions and filters related to the Gravity Forms plugin.
+ *
+ * @package themeslug
  */
 
 
@@ -60,7 +62,7 @@ add_filter('gform_submit_button', 'themeslug_gform_input_to_button', 10, 2);
  *
  * @link https://docs.gravityforms.com/gform_submit_button/#h-5-append-custom-css-classes-to-the-button
  *
- * @return void
+ * @return string
  */
 function themeslug_gform_add_custom_css_classes($button, $form) {
 	$fragment = WP_HTML_Processor::create_fragment($button);
@@ -69,4 +71,70 @@ function themeslug_gform_add_custom_css_classes($button, $form) {
 
 	return $fragment->get_updated_html();
 }
-add_filter( 'gform_submit_button', 'themeslug_gform_add_custom_css_classes', 10, 2 );
+add_filter( 'gform_submit_button', 'themeslug_gform_add_custom_css_classes', 15, 2 );
+
+
+/**
+ * Adds custom data- attributes to the submit button for specific forms.
+ *
+ * This function uses a centralized configuration array to apply various
+ * data attributes to the submit buttons of specified Gravity Forms.
+ *
+ * @since WordPress 6.6
+ *
+ * @param string $button The HTML for the button element.
+ * @param array  $form   The current form object.
+ * @return string The modified button HTML with data attributes.
+ */
+function themeslug_gform_add_data_attributes( $button, $form ) {
+	// Early return if there's no button HTML to process.
+	if ( empty( $button ) ) {
+		return $button;
+	}
+
+	$form_id = $form['id'];
+
+	/**
+	 * Configuration for data attributes.
+	 *
+	 * Structure:
+	 * 'data-attribute-name' => [
+	 * 'attribute_value' => [ form_id_1, form_id_2, ... ],
+	 * 'another_value'   => [ form_id_3, ... ],
+	 * ],
+	 */
+	$config = [
+		'data-appearance' => [
+			'inverse' => [  ],
+			'outlined' => [  ],
+			'plain' => [  ],
+		],
+	];
+
+	// Find all attributes that should be applied to the current form.
+	$attributes_to_set = [];
+	foreach ( $config as $attribute_name => $value_map ) {
+		foreach ( $value_map as $attribute_value => $form_ids ) {
+			if ( in_array( $form_id, $form_ids, true ) ) {
+				$attributes_to_set[ $attribute_name ] = $attribute_value;
+				break; // Found the value for this attribute, move to the next one.
+			}
+		}
+	}
+
+	// If no attributes were found for this form, return the button without changes.
+	if ( empty( $attributes_to_set ) ) {
+		return $button;
+	}
+
+	$fragment = WP_HTML_Processor::create_fragment( $button );
+
+	if ( $fragment->next_tag() ) {
+		foreach ( $attributes_to_set as $name => $value ) {
+			$fragment->set_attribute( $name, $value );
+		}
+	}
+
+	return $fragment->get_updated_html();
+}
+add_filter( 'gform_submit_button', 'themeslug_gform_add_data_attributes', 20, 2 );

--- a/includes/plugin-gravityforms.php
+++ b/includes/plugin-gravityforms.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Gravity Forms customizations.
+ *
+ * All actions and filters related to the Gravity Forms plugin.
+ */
+
+
+/**
+ * Disable the CSS of the default theme used by forms created with Gravity Forms 2.5 and greater.
+ *
+ * @since Gravity Forms v2.5
+ *
+ * @link https://docs.gravityforms.com/gform_disable_form_theme_css/
+ *
+ * @param bool $disabled Whether to disable the theme CSS.
+ */
+add_filter( 'gform_disable_form_theme_css', '__return_true' );
+
+
+/**
+ * Filter the next, previous and submit buttons.
+ *
+ * Replace the form's input buttons with button elements, while maintaining attributes from original input.
+ * Reason: "button elements are much easier to style than input elements" (see
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#notes).
+ *
+ * @since WordPress 6.6
+ *
+ * @link https://docs.gravityforms.com/gform_submit_button/#h-1-change-input-to-button
+ *
+ * @param string $button Contains the input tag to be filtered.
+ * @param array  $form   Contains all the properties of the current form.
+ * @return string The filtered button.
+ */
+function themeslug_gform_input_to_button($button, $form) {
+	$fragment = \WP_HTML_Processor::create_fragment($button);
+	$fragment->next_token();
+
+	$attributes = array('id', 'type', 'class', 'onclick');
+	$new_attributes = array();
+	foreach ($attributes as $attribute) {
+		$value = $fragment->get_attribute($attribute);
+		if (! empty($value)) {
+			$new_attributes[] = sprintf('%s="%s"', $attribute, esc_attr($value));
+		}
+	}
+
+	return sprintf('<button %s>%s</button>', implode(' ', $new_attributes), esc_html($fragment->get_attribute('value')));
+}
+add_filter('gform_next_button', 'themeslug_gform_input_to_button', 10, 2);
+add_filter('gform_previous_button', 'themeslug_gform_input_to_button', 10, 2);
+add_filter('gform_submit_button', 'themeslug_gform_input_to_button', 10, 2);
+
+
+/**
+ * Add custom CSS classes to the submit button.
+ *
+ * @since WordPress 6.6
+ *
+ * @link https://docs.gravityforms.com/gform_submit_button/#h-5-append-custom-css-classes-to-the-button
+ *
+ * @return void
+ */
+function themeslug_gform_add_custom_css_classes($button, $form) {
+	$fragment = WP_HTML_Processor::create_fragment($button);
+	$fragment->next_token();
+	$fragment->add_class('button');
+
+	return $fragment->get_updated_html();
+}
+add_filter( 'gform_submit_button', 'themeslug_gform_add_custom_css_classes', 10, 2 );

--- a/includes/styles.php
+++ b/includes/styles.php
@@ -172,6 +172,7 @@ function themeslug_get_layer_config() {
 		// Maps specific stylesheet 'handles' to a layer.
 		'map' => [
 			'themeslug-styles' => 'theme',
+			'gform_basic'      => 'plugins',
 			// e.g. 'plugin_handle' => 'plugins',
 		],
 		// The default layer for any handle not found in the map.

--- a/includes/styles.php
+++ b/includes/styles.php
@@ -123,12 +123,23 @@ add_action('wp_enqueue_scripts', 'themeslug_remove_wp_block_styles', 10);
  * @return void
  */
 function themeslug_enqueue_styles() {
-	$theme_version = wp_get_theme()->get( 'Version' );
+	$theme_version = wp_get_theme()->get('Version');
+	$dependencies = [];
+
+	/**
+	 * Make the theme's main stylesheet dependent on the Gravity Forms basic stylesheet.
+	 * This ensures the theme's CSS loads *after* the plugin's CSS, which allows
+	 * for easy style overrides without increasing specificity or using `!important`.
+	 * The `wp_style_is()` check prevents errors if Gravity Forms is not active.
+	 */
+	if ( wp_style_is( 'gform_basic-css', 'registered' ) ) {
+		$dependencies[] = 'gform_basic-css';
+	}
 
 	wp_enqueue_style(
 		'themeslug-styles',
-		get_theme_file_uri( 'build/styles/global.css' ),
-		[],
+		get_theme_file_uri('build/styles/global.css'),
+		$dependencies,
 		$theme_version
 	);
 }

--- a/src/styles/blocks/gravityforms.css
+++ b/src/styles/blocks/gravityforms.css
@@ -1,0 +1,93 @@
+/* ======================================================================
+gravityforms/form
+---
+Source:          URL
+Block Reference: URL
+---
+Notes:
+- To customize most of this block and its parts, use the custom properties.
+====================================================================== */
+
+/* Selector is repeated to increase specificity to override GF styles */
+.gform_wrapper.gform_wrapper {
+	/* Hide the required field legend */
+	.gform_required_legend {
+		display: none;
+	}
+
+	/* Hide the required asterisk */
+	.gfield_required_asterisk {
+		display: none;
+	}
+
+	.gform-body + .gform-footer:has(> :not([type="hidden"])) {
+		margin-block-start: var(--flow-space, 1em);
+	}
+
+	.gfield_description,
+	.gfield_validation_message {
+		font-size: var(--font-size-base, inherit);
+	}
+
+	&.gravity-theme {
+		.gform_fields {
+			row-gap: var(--gutter, 1em);
+			column-gap: 0; /* This avoid overflowing issues with GF default grid-template-columns */
+		}
+
+		/* Revert GF styles */
+		.gfield textarea.large {
+			height: revert;
+		}
+
+		/* Revert GF styles */
+		@media only screen and (width <= 641px) {
+			/* stylelint-disable-next-line selector-not-notation -- To match GF selector specificity. */
+			input:not([type="checkbox"]):not([type="image"]):not([type="file"]) {
+				min-height: revert !important;
+				line-height: inherit !important;
+			}
+
+			textarea {
+				line-height: inherit !important;
+			}
+		}
+	}
+
+	/* ----------------------------------------------------------------------
+	Error messages
+	---------------------------------------------------------------------- */
+
+	.gform_validation_errors {
+		color: var(--color-error, inherit);
+	}
+
+	.gform_submission_error {
+		font-size: inherit;
+		font-weight: inherit;
+
+		&:has(> [class*="icon"]) {
+			display: flex;
+			gap: 0.5em;
+			align-items: flex-start;
+		}
+
+		> [class*="icon"] {
+			flex-shrink: 0;
+			padding-block: 0.25em;
+		}
+	}
+
+	&:has(.gform_validation_errors) {
+		:is(label, input, textarea, .validation_message.gfield_validation_message) {
+			color: var(--color-error, inherit);
+		}
+
+		:is(input, textarea) {
+			outline-width: var(--focus-ring-width, 2px);
+			outline-style: solid;
+			outline-color: currentcolor;
+			outline-offset: 0;
+		}
+	}
+}

--- a/src/styles/blocks/gravityforms.css
+++ b/src/styles/blocks/gravityforms.css
@@ -8,8 +8,42 @@ Notes:
 - To customize most of this block and its parts, use the custom properties.
 ====================================================================== */
 
+/* stylelint-disable selector-not-notation -- To match GF selector specificity. */
+
 /* Selector is repeated to increase specificity to override GF styles */
-.gform_wrapper.gform_wrapper {
+.gform_wrapper.gravity-theme {
+	/* ----------------------------------------------------------------------
+	Revert GF default styles
+	---------------------------------------------------------------------- */
+
+	.gfield textarea.large {
+		height: revert;
+	}
+
+	@media only screen and (width <= 641px) {
+		input:not([type="radio"]):not([type="checkbox"]):not([type="image"]):not([type="file"]) {
+			line-height: inherit;
+		}
+
+		textarea {
+			line-height: inherit;
+		}
+	}
+
+	/* ----------------------------------------------------------------------
+	Custom styles
+	---------------------------------------------------------------------- */
+
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6,
+	p {
+		margin-block: 0;
+	}
+
 	/* Hide the required field legend */
 	.gform_required_legend {
 		display: none;
@@ -20,74 +54,51 @@ Notes:
 		display: none;
 	}
 
-	.gform-body + .gform-footer:has(> :not([type="hidden"])) {
-		margin-block-start: var(--flow-space, 1em);
+	.gform_fields {
+		row-gap: var(--form-fields-gap-rows, var(--gutter));
+		column-gap: 0; /* This avoid overflowing issues with GF default grid-template-columns */
 	}
 
-	.gfield_description,
-	.gfield_validation_message {
-		font-size: var(--font-size-base, inherit);
+	.gfield {
+		--flow-space: 0.875rem;
 	}
 
-	&.gravity-theme {
-		.gform_fields {
-			row-gap: var(--gutter, 1em);
-			column-gap: 0; /* This avoid overflowing issues with GF default grid-template-columns */
-		}
+	.gform-footer {
+		--flow-space: var(--form-fields-gap-rows, var(--gutter));
+	}
 
-		/* Revert GF styles */
-		.gfield textarea.large {
-			height: revert;
-		}
-
-		/* Revert GF styles */
-		@media only screen and (width <= 641px) {
-			/* stylelint-disable-next-line selector-not-notation -- To match GF selector specificity. */
-			input:not([type="checkbox"]):not([type="image"]):not([type="file"]) {
-				min-height: revert !important;
-				line-height: inherit !important;
-			}
-
-			textarea {
-				line-height: inherit !important;
-			}
+	.flow {
+		.gfield_radio > .gchoice + .gchoice {
+			margin-block-start: var(--flow-space);
 		}
 	}
 
-	/* ----------------------------------------------------------------------
-	Error messages
-	---------------------------------------------------------------------- */
+	/*
+	Errors
+	*/
+
+	&:has(.gform_validation_errors) {
+		--field-border-color: var(--field-error-color);
+		--field-color: var(--field-error-color);
+
+		.gfield_validation_message {
+			color: var(--field-error-color, inherit);
+		}
+	}
 
 	.gform_validation_errors {
-		color: var(--color-error, inherit);
+		padding: 1em;
+		color: var(--field-error-color, inherit);
+		border: 2px solid;
 	}
 
 	.gform_submission_error {
-		font-size: inherit;
-		font-weight: inherit;
+		font: inherit;
 
-		&:has(> [class*="icon"]) {
-			display: flex;
-			gap: 0.5em;
-			align-items: flex-start;
-		}
-
-		> [class*="icon"] {
-			flex-shrink: 0;
-			padding-block: 0.25em;
-		}
-	}
-
-	&:has(.gform_validation_errors) {
-		:is(label, input, textarea, .validation_message.gfield_validation_message) {
-			color: var(--color-error, inherit);
-		}
-
-		:is(input, textarea) {
-			outline-width: var(--focus-ring-width, 2px);
-			outline-style: solid;
-			outline-color: currentcolor;
-			outline-offset: 0;
+		.gform-icon {
+			float: left;
+			margin-inline-end: 1ch;
+			line-height: inherit;
 		}
 	}
 }


### PR DESCRIPTION
Introduce a complete integration layer for the Gravity Forms plugin,
including custom functionality and dedicated styling.

- **PHP:**
  - Add a new `includes/plugin-gravityforms.php` file with multiple
    functions to customize form buttons using the HTML API.
  - Disable the default Gravity Forms theme CSS.
  - Ensure the theme's stylesheet loads *after* the plugin's CSS for
    easy style overrides.

- **CSS:**
  - Add a new `gravityforms.css` stylesheet to align form appearance
    with the theme's design system and improve error state visuals.